### PR TITLE
feat(map): refacto mapview, toggle et layout

### DIFF
--- a/src/components/InteractiveMap.tsx
+++ b/src/components/InteractiveMap.tsx
@@ -59,25 +59,32 @@ interface InteractiveMapProps {
   selectedReport: MockReport | null;
   onReportSelect: (report: MockReport) => void;
   filteredType: string;
+  filteredStatus?: string;
 }
 
 export const InteractiveMap: React.FC<InteractiveMapProps> = ({
   reports,
   selectedReport,
   onReportSelect,
-  filteredType
+  filteredType,
+  filteredStatus = 'all'
 }) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const isMapInitialized = useRef(false);
 
-  // Filter reports based on selected type
-  const filteredReports = filteredType === 'all' 
-    ? reports 
-    : reports.filter(report => report.type === filteredType);
+  let filteredReports = reports;
+  
+  if (filteredType !== 'all') {
+    filteredReports = filteredReports.filter(report => report.type === filteredType);
+  }
+  
+  if (filteredStatus !== 'all') {
+    filteredReports = filteredReports.filter(report => report.status === filteredStatus);
+  }
 
-  // Create custom icon for each pollution type
+
   const createCustomIcon = (type: string, isSelected: boolean = false) => {
     const color = pollutionTypeColors[type as keyof typeof pollutionTypeColors];
     const size = isSelected ? 35 : 25;
@@ -113,11 +120,10 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
     });
   };
 
-  // Initialize map
+  
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current || isMapInitialized.current) return;
 
-    // Create map centered on French Atlantic coast
     try {
       const map = L.map(mapRef.current, {
         preferCanvas: true,
@@ -125,7 +131,6 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
         attributionControl: true
       }).setView([44.5, -1.0], 8);
 
-      // Add OpenStreetMap tiles
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         maxZoom: 18
@@ -150,11 +155,9 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
     };
   }, []);
 
-  // Update markers when reports change
   useEffect(() => {
     if (!mapInstanceRef.current || !isMapInitialized.current) return;
 
-    // Clear existing markers
     markersRef.current.forEach(marker => {
       try {
         if (mapInstanceRef.current && marker) {
@@ -166,11 +169,9 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
     });
     markersRef.current = [];
 
-    // Add new markers
     filteredReports.forEach(report => {
       if (!mapInstanceRef.current || !isMapInitialized.current) return;
       
-      // Debug des coordonnées
       console.debug('Création marqueur pour:', report.location_address);
       console.debug('Coordonnées:', report.location_lat, report.location_lng, typeof report.location_lat, typeof report.location_lng);
       
@@ -192,7 +193,6 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
           icon: createCustomIcon(report.type, isSelected)
         });
 
-        // Create popup content
         const popupContent = `
           <div class="p-3 min-w-64">
             <div class="flex items-center justify-between mb-3">
@@ -234,7 +234,6 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
           className: 'custom-popup'
         });
 
-        // Handle marker click
         marker.on('click', () => {
           onReportSelect(report);
         });
@@ -248,7 +247,6 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
       }
     });
 
-    // Fit map to show all markers if there are any
     if (filteredReports.length > 0 && markersRef.current.length > 0 && mapInstanceRef.current) {
       try {
         const group = new L.FeatureGroup(markersRef.current);
@@ -262,7 +260,6 @@ export const InteractiveMap: React.FC<InteractiveMapProps> = ({
     }
   }, [filteredReports, selectedReport, onReportSelect]);
 
-  // Update marker styles when selection changes
   useEffect(() => {
     if (!mapInstanceRef.current || !isMapInitialized.current) return;
 

--- a/src/components/dashboard/PollutionTypeChart.tsx
+++ b/src/components/dashboard/PollutionTypeChart.tsx
@@ -52,7 +52,9 @@ export const PollutionTypeChart: React.FC<PollutionTypeChartProps> = ({
       </div>
       
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-        {Object.entries(pollutionTypeData).map(([type, count]) => {
+        {Object.entries(pollutionTypeData)
+          .filter(([type]) => typeLabels[type]) // Filtrer seulement les types reconnus
+          .map(([type, count]) => {
           const typeInfo = typeLabels[type];
           const percentage = total > 0 ? Math.round((count / total) * 100) : 0;
           

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,14 +1,15 @@
 /**
  * @fileoverview Page de visualisation cartographique des signalements
  * 
- * Cette page affiche tous les signalements sur une carte interactive avec
- * filtrage par type de pollution. Elle permet la consultation détaillée
- * et la suppression des signalements existants.
+ * Cette page affiche tous les signalements avec un système de toggle entre
+ * vue carte et vue liste. Elle permet le filtrage par type de pollution
+ * et par statut, avec consultation détaillée des signalements.
  * 
  * @features
+ * - Toggle entre vue carte et vue liste
+ * - Filtres par type de pollution et statut
  * - Carte interactive avec Leaflet
- * - Filtres par type de pollution
- * - Liste des signalements avec sélection
+ * - Liste des signalements avec pagination
  * - Détails complets des signalements sélectionnés
  * - Suppression avec confirmation
  * - Marqueurs colorés par type de pollution
@@ -17,19 +18,24 @@
  * @dependencies InteractiveMap, mockData, Lucide React
  */
 import React, { useState, useEffect } from 'react';
-import { Filter, MapPin, Calendar, User, Eye } from 'lucide-react';
+import { Filter, MapPin, Calendar, User, Eye, Map, List, Grid } from 'lucide-react';
 import { getMockReports, MockReport, deleteMockReport } from '../lib/mockData';
 import { DeleteReportModal } from '../components/dashboard/DeleteReportModal';
 import { InteractiveMap } from '../components/InteractiveMap';
 import { getImage } from '../lib/imageStorage';
 import { ImagePreview } from '../components/ImagePreview';
 
+type ViewMode = 'map' | 'list';
+
 export const MapPage: React.FC = () => {
+  // Scroll to top on component mount
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
+  const [viewMode, setViewMode] = useState<ViewMode>('map');
   const [selectedType, setSelectedType] = useState('all');
+  const [selectedStatus, setSelectedStatus] = useState('all');
   const [selectedReport, setSelectedReport] = useState<MockReport | null>(null);
   const [reports, setReports] = useState<MockReport[]>([]);
   const [loading, setLoading] = useState(true);
@@ -95,6 +101,13 @@ export const MapPage: React.FC = () => {
     { value: 'other', label: 'Autre', color: 'bg-gray-600', count: reports.filter(r => r.type === 'other').length }
   ];
 
+  const statusTypes = [
+    { value: 'all', label: 'Tous statuts', count: reports.length },
+    { value: 'new', label: 'Nouveaux', count: reports.filter(r => r.status === 'new').length },
+    { value: 'in-progress', label: 'En cours', count: reports.filter(r => r.status === 'in-progress').length },
+    { value: 'resolved', label: 'Résolus', count: reports.filter(r => r.status === 'resolved').length }
+  ];
+
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'new': return 'bg-red-100 text-red-800';
@@ -113,9 +126,16 @@ export const MapPage: React.FC = () => {
     }
   };
 
-  const filteredReports = selectedType === 'all' 
-    ? reports 
-    : reports.filter(report => report.type === selectedType);
+
+  let filteredReports = reports;
+  
+  if (selectedType !== 'all') {
+    filteredReports = filteredReports.filter(report => report.type === selectedType);
+  }
+  
+  if (selectedStatus !== 'all') {
+    filteredReports = filteredReports.filter(report => report.status === selectedStatus);
+  }
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -129,22 +149,23 @@ export const MapPage: React.FC = () => {
           </p>
         </div>
 
-        <div className="grid lg:grid-cols-4 gap-6">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+            {error}
+          </div>
+        )}
+
+        {/* View Toggle and Filters */}
+        <div className="bg-white rounded-lg shadow-lg p-6 mb-6">
           {/* Filters */}
-          <div className="lg:col-span-1 order-2 lg:order-1">
-            {error && (
-              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4">
-                {error}
+          <div className="grid md:grid-cols-2 gap-6">
+            {/* Type Filter */}
+            <div>
+              <div className="flex items-center space-x-2 mb-3">
+                <Filter className="h-4 w-4 text-gray-600" />
+                <h3 className="text-sm font-medium text-gray-700">Type de pollution</h3>
               </div>
-            )}
-            
-            <div className="bg-white rounded-lg shadow-lg p-6">
-              <div className="flex items-center space-x-2 mb-4">
-                <Filter className="h-5 w-5 text-gray-600" />
-                <h2 className="text-lg font-semibold text-gray-800">Filtres</h2>
-              </div>
-              
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {pollutionTypes.map(type => (
                   <label key={type.value} className="flex items-center space-x-3 cursor-pointer">
                     <input
@@ -153,7 +174,7 @@ export const MapPage: React.FC = () => {
                       value={type.value}
                       checked={selectedType === type.value}
                       onChange={(e) => setSelectedType(e.target.value)}
-                      className="text-blue-600"
+                      className="text-sky-600"
                     />
                     <div className={`w-3 h-3 rounded-full ${type.color}`}></div>
                     <span className="text-sm text-gray-700 flex-1">{type.label}</span>
@@ -165,153 +186,329 @@ export const MapPage: React.FC = () => {
               </div>
             </div>
 
-            {/* Reports List */}
-            <div className="bg-white rounded-lg shadow-lg p-6 mt-6">
-              <h2 className="text-lg font-semibold text-gray-800 mb-4">
-                Signalements ({loading ? '...' : filteredReports.length})
-              </h2>
-              
-              {loading ? (
-                <div className="flex items-center justify-center py-8">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-                </div>
-              ) : (
-                <div className="space-y-3 max-h-96 overflow-y-auto">
-                  {filteredReports.map(report => (
-                    <div
-                      key={report.id}
-                      onClick={() => setSelectedReport(report)}
-                      className={`p-3 rounded-lg border cursor-pointer transition-colors ${
-                        selectedReport?.id === report.id
-                          ? 'border-sky-500 bg-sky-50'
-                          : 'border-gray-200 hover:bg-gray-50'
-                      }`}
-                    >
-                      <div className="flex items-start justify-between mb-2">
-                        <div className={`w-3 h-3 rounded-full ${
-                          pollutionTypes.find(t => t.value === report.type)?.color || 'bg-gray-500'
-                        }`}></div>
-                        <span className={`text-xs px-2 py-1 rounded-full ${getStatusColor(report.status)}`}>
-                          {getStatusLabel(report.status)}
-                        </span>
-                      </div>
-                      <p className="text-sm font-medium text-gray-800 mb-1">
-                        {report.location_address}
-                      </p>
-                      <p className="text-xs text-gray-600 truncate">
-                        {report.description}
-                      </p>
-                      <p className="text-xs text-gray-500 mt-1">
-                        {new Date(report.created_at).toLocaleDateString('fr-FR')}
-                      </p>
-                    </div>
-                  ))}
-                  
-                  {filteredReports.length === 0 && !loading && (
-                    <p className="text-gray-500 text-center py-4">
-                      Aucun signalement trouvé
-                    </p>
-                  )}
-                </div>
-              )}
+            {/* Status Filter */}
+            <div>
+              <div className="flex items-center space-x-2 mb-3">
+                <Eye className="h-4 w-4 text-gray-600" />
+                <h3 className="text-sm font-medium text-gray-700">Statut</h3>
+              </div>
+              <div className="space-y-2">
+                {statusTypes.map(status => (
+                  <label key={status.value} className="flex items-center space-x-3 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="status-type"
+                      value={status.value}
+                      checked={selectedStatus === status.value}
+                      onChange={(e) => setSelectedStatus(e.target.value)}
+                      className="text-sky-600"
+                    />
+                    <span className="text-sm text-gray-700 flex-1">{status.label}</span>
+                    <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded-full">
+                      {status.count}
+                    </span>
+                  </label>
+                ))}
+              </div>
             </div>
           </div>
+        </div>
 
-          {/* Map */}
-          <div className="lg:col-span-3 order-1 lg:order-2">
-            <div className="bg-white rounded-lg shadow-lg p-6">
-              <div className="h-[400px] md:h-[500px] lg:h-[600px]">
-                {loading ? (
-                  <div className="h-full bg-gray-100 rounded-lg flex items-center justify-center">
-                    <div className="text-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-600 mx-auto mb-4"></div>
-                      <p className="text-gray-600">Chargement de la carte...</p>
+        {/* View Toggle */}
+        <div className="bg-white rounded-lg shadow-lg p-4 mb-6">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-center space-x-2">
+              <span className="text-sm font-medium text-gray-700">Vue :</span>
+              <div className="bg-gray-100 rounded-lg p-1 flex">
+                <button
+                  onClick={() => setViewMode('map')}
+                  className={`flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                    viewMode === 'map'
+                      ? 'bg-white text-sky-700 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  <Map className="h-4 w-4" />
+                  <span>Carte</span>
+                </button>
+                <button
+                  onClick={() => setViewMode('list')}
+                  className={`flex items-center space-x-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                    viewMode === 'list'
+                      ? 'bg-white text-sky-700 shadow-sm'
+                      : 'text-gray-600 hover:text-gray-800'
+                  }`}
+                >
+                  <List className="h-4 w-4" />
+                  <span>Liste</span>
+                </button>
+              </div>
+            </div>
+
+            {/* Results count */}
+            <div className="text-sm text-gray-600">
+              {loading ? 'Chargement...' : `${filteredReports.length} signalement(s) trouvé(s)`}
+            </div>
+          </div>
+        </div>
+
+        {/* Content based on view mode */}
+        {viewMode === 'map' ? (
+          /* Map View */
+          <div className="grid lg:grid-cols-3 gap-6">
+            {/* Map */}
+            <div className="lg:col-span-2">
+              <div className="bg-white rounded-lg shadow-lg p-6">
+                <div className="h-[500px] lg:h-[600px]">
+                  {loading ? (
+                    <div className="h-full bg-gray-100 rounded-lg flex items-center justify-center">
+                      <div className="text-center">
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-600 mx-auto mb-4"></div>
+                        <p className="text-gray-600">Chargement de la carte...</p>
+                      </div>
                     </div>
-                  </div>
-                ) : (
-                  <InteractiveMap
-                    reports={reports}
-                    selectedReport={selectedReport}
-                    onReportSelect={setSelectedReport}
-                    filteredType={selectedType}
-                  />
-                )}
+                  ) : (
+                    <InteractiveMap
+                      reports={reports}
+                      selectedReport={selectedReport}
+                      onReportSelect={setSelectedReport}
+                      filteredType={selectedType}
+                      filteredStatus={selectedStatus}
+                    />
+                  )}
+                </div>
               </div>
             </div>
 
             {/* Selected Report Details */}
+            <div className="lg:col-span-1">
+              {selectedReport ? (
+                <div className="bg-white rounded-lg shadow-lg p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <h3 className="text-lg font-semibold text-gray-800">
+                      Détails du signalement
+                    </h3>
+                    <span className={`px-3 py-1 rounded-full text-sm ${getStatusColor(selectedReport.status)}`}>
+                      {getStatusLabel(selectedReport.status)}
+                    </span>
+                  </div>
+                  
+                  <div className="space-y-4">
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <MapPin className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Localisation</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {selectedReport.location_address}
+                      </p>
+                    </div>
+                    
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <Calendar className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Date</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {new Date(selectedReport.created_at).toLocaleDateString('fr-FR')}
+                      </p>
+                    </div>
+                    
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <User className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Signalé par</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {selectedReport.organization_name || 'Équipe non spécifiée'}
+                      </p>
+                    </div>
+                    
+                    <div>
+                      <h4 className="text-sm font-medium text-gray-700 mb-2">Description</h4>
+                      <p className="text-sm text-gray-600">
+                        {selectedReport.description}
+                      </p>
+                    </div>
+                    
+                    {(selectedReportImage || selectedReport.photo_url) && (
+                      <div>
+                        <h4 className="text-sm font-medium text-gray-700 mb-2">Photo</h4>
+                        <ImagePreview
+                          image={selectedReportImage || selectedReport.photo_url || null}
+                          showRemoveButton={false}
+                          showModifyButton={false}
+                          alt="Photo du signalement"
+                          className="w-full max-w-md"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="bg-white rounded-lg shadow-lg p-6">
+                  <div className="text-center py-8">
+                    <MapPin className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-gray-800 mb-2">
+                      Sélectionnez un signalement
+                    </h3>
+                    <p className="text-gray-600">
+                      Cliquez sur un marqueur de la carte pour voir les détails
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          /* List View */
+          <div className="space-y-6">
+            {/* Reports List - Full Width */}
+            <div className="bg-white rounded-lg shadow-lg p-6">
+              <h2 className="text-lg font-semibold text-gray-800 mb-4">
+                Liste des signalements ({filteredReports.length})
+              </h2>
+              
+              {loading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sky-600"></div>
+                </div>
+              ) : (
+                <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {filteredReports.map(report => (
+                    <div
+                      key={report.id}
+                      onClick={() => setSelectedReport(report)}
+                      className={`p-4 rounded-lg border cursor-pointer transition-all hover:shadow-md ${
+                        selectedReport?.id === report.id
+                          ? 'border-sky-500 bg-sky-50 shadow-md'
+                          : 'border-gray-200 hover:bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between mb-3">
+                        <div className="flex items-center space-x-3">
+                          <div className={`w-4 h-4 rounded-full ${
+                            pollutionTypes.find(t => t.value === report.type)?.color || 'bg-gray-500'
+                          }`}></div>
+                          <h4 className="font-medium text-gray-800 text-sm">
+                            {pollutionTypes.find(t => t.value === report.type)?.label}
+                          </h4>
+                        </div>
+                        <span className={`text-xs px-2 py-1 rounded-full ${getStatusColor(report.status)}`}>
+                          {getStatusLabel(report.status)}
+                        </span>
+                      </div>
+                      
+                      <div className="space-y-2">
+                        <div className="flex items-start space-x-2">
+                          <MapPin className="h-4 w-4 text-gray-500 mt-0.5 flex-shrink-0" />
+                          <p className="text-sm text-gray-700 font-medium line-clamp-2">
+                            {report.location_address}
+                          </p>
+                        </div>
+                        
+                        <div className="flex items-center space-x-4 text-xs text-gray-500">
+                          <div className="flex items-center space-x-1">
+                            <Calendar className="h-3 w-3" />
+                            <span>{new Date(report.created_at).toLocaleDateString('fr-FR')}</span>
+                          </div>
+                          <div className="flex items-center space-x-1">
+                            <User className="h-3 w-3" />
+                            <span>{report.organization_name || 'Équipe terrain'}</span>
+                          </div>
+                        </div>
+                        
+                        <p className="text-sm text-gray-600 line-clamp-3">
+                          {report.description}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                  
+                  {filteredReports.length === 0 && (
+                    <div className="col-span-full text-center py-8">
+                      <Grid className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                      <h3 className="text-lg font-medium text-gray-800 mb-2">
+                        Aucun signalement trouvé
+                      </h3>
+                      <p className="text-gray-600">
+                        Essayez de modifier les filtres pour voir plus de résultats
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Selected Report Details - Full Width Below */}
             {selectedReport && (
-              <div className="bg-white rounded-lg shadow-lg p-6 mt-6">
+              <div className="bg-white rounded-lg shadow-lg p-6">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-semibold text-gray-800">
-                    Détails du signalement
+                    Détails du signalement sélectionné
                   </h3>
                   <span className={`px-3 py-1 rounded-full text-sm ${getStatusColor(selectedReport.status)}`}>
                     {getStatusLabel(selectedReport.status)}
                   </span>
                 </div>
                 
-                <div className="grid md:grid-cols-2 gap-4">
-                  <div>
-                    <div className="flex items-center space-x-2 mb-2">
-                      <MapPin className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium text-gray-700">Localisation</span>
+                <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  <div className="space-y-4">
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <MapPin className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Localisation</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {selectedReport.location_address}
+                      </p>
                     </div>
-                    <p className="text-sm text-gray-600 mb-4">
-                      {selectedReport.location_address}
-                    </p>
                     
-                    <div className="flex items-center space-x-2 mb-2">
-                      <Calendar className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium text-gray-700">Date</span>
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <Calendar className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Date</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {new Date(selectedReport.created_at).toLocaleDateString('fr-FR')}
+                      </p>
                     </div>
-                    <p className="text-sm text-gray-600 mb-4">
-                      {new Date(selectedReport.created_at).toLocaleDateString('fr-FR')}
-                    </p>
+                    
+                    <div>
+                      <div className="flex items-center space-x-2 mb-2">
+                        <User className="h-4 w-4 text-gray-500" />
+                        <span className="text-sm font-medium text-gray-700">Signalé par</span>
+                      </div>
+                      <p className="text-sm text-gray-600">
+                        {selectedReport.organization_name || 'Équipe non spécifiée'}
+                      </p>
+                    </div>
                   </div>
                   
                   <div>
-                    <div className="flex items-center space-x-2 mb-2">
-                      <User className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium text-gray-700">Signalé par</span>
-                    </div>
-                    <p className="text-sm text-gray-600 mb-4">
-                      {selectedReport.organization_name || 'Équipe non spécifiée'}
-                    </p>
-                    
-                    <div className="flex items-center space-x-2 mb-2">
-                      <Eye className="h-4 w-4 text-gray-500" />
-                      <span className="text-sm font-medium text-gray-700">Type</span>
-                    </div>
+                    <h4 className="text-sm font-medium text-gray-700 mb-2">Description</h4>
                     <p className="text-sm text-gray-600">
-                      {pollutionTypes.find(t => t.value === selectedReport.type)?.label}
+                      {selectedReport.description}
                     </p>
                   </div>
+                  
+                  {(selectedReportImage || selectedReport.photo_url) && (
+                    <div>
+                      <h4 className="text-sm font-medium text-gray-700 mb-2">Photo</h4>
+                      <ImagePreview
+                        image={selectedReportImage || selectedReport.photo_url || null}
+                        showRemoveButton={false}
+                        showModifyButton={false}
+                        alt="Photo du signalement"
+                        className="w-full max-w-md"
+                      />
+                    </div>
+                  )}
                 </div>
-                
-                <div className="mt-4">
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Description</h4>
-                  <p className="text-sm text-gray-600">
-                    {selectedReport.description}
-                  </p>
-                </div>
-                
-                {(selectedReportImage || selectedReport.photo_url) && (
-                  <div className="mt-4">
-                    <h4 className="text-sm font-medium text-gray-700 mb-2">Photo</h4>
-                    <ImagePreview
-                      image={selectedReportImage || selectedReport.photo_url || null}
-                      showRemoveButton={false}
-                      showModifyButton={false}
-                      alt="Photo du signalement"
-                      className="w-full max-w-md"
-                    />
-                  </div>
-                )}
               </div>
             )}
           </div>
-        </div>
+        )}
       </div>
       
       {/* Delete Confirmation Modal */}


### PR DESCRIPTION
⚠️ Cette PR est empilée sur #2.  
Merci de relire/valider la PR reporting (#2) avant celle-ci.

# Objet
Refonte complète de la vue Liste/Carte pour supprimer le double scroll, améliorer la hiérarchie visuelle et rendre l’interface plus claire et responsive sur tous les écrans.

- Liste en grille (pleine largeur, responsive 1→2→3 colonnes)  
- Détails affichés en dessous de la liste (pleine largeur)  
- Nouvelle organisation : Filtres en haut, Toggle au milieu, Contenu en bas  
- Interface plus claire, lisible et mieux adaptée aux différents écrans  

# Changements clés
## Vue Liste
- Grille responsive : 1 col. mobile → 2 col. tablette → 3 col. desktop  
- Cartes compactes avec infos essentielles  
- Suppression du scroll interne (scroll naturel de la page)  
- Sélection visuelle nette (bordure bleue)

## Vue Détails
- Affichage uniquement lorsqu’un signalement est sélectionné  
- Pleine largeur, 3 colonnes : infos de base | description | photo  
- Plus de panneau latéral qui causait un double scroll

## Structure réorganisée
1. **Filtres (haut)** : filtres type pollution + statut, padding généreux (`p-6`)  
2. **Toggle (milieu)** : switch Carte/Liste + compteur résultats, padding compact (`p-4`), layout vertical (mobile) / horizontal (desktop)  
3. **Contenu (bas)** : affichage Carte ou Liste selon sélection  

## Problèmes résolus
- Double scroll supprimé  
- Meilleure utilisation de l’espace écran  
- Séparation claire Liste / Détails  
- Responsive sur tous les écrans  

# Comment tester (recette)
**A. Layout Liste**  
- Passer en Vue Liste → redimensionner (375 / 768 / 1024 / 1440)  


**B. Sélection & détails**  
- Cliquer un signalement  


**C. Filtres & statut**  
- Filtrer par type + statut  


**D. Toggle & hiérarchie**  
- Utiliser le switch Carte/Liste  


**E. Non régressions**  
- Vue Carte inchangée côté comportement  
- Aucun double scroll  
- Cross-browser (Chrome / Firefox / Safari) OK  

# Risques / Rollback
- Risque de régression CSS (breakpoints responsive)  
- Vérifier cohérence des clés/états de sélection Liste/Détails  
**Rollback** : revert du merge sur `staging`.  
